### PR TITLE
fix(bench): harden live suite against vacuous passes (#3, #4, #5)

### DIFF
--- a/src/localharness/bench/schema.py
+++ b/src/localharness/bench/schema.py
@@ -129,6 +129,25 @@ class SuccessCriteria(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def reject_vacuous_rubric(self) -> "SuccessCriteria":
+        """An empty needle/pattern matches EVERY output — `"" in text` and `re.search("", text)`
+        are both always True — so a scenario with e.g. `contains:` (nothing after the colon) scores
+        even a run that errored before emitting a token 1.0. Reject it at load, not at score time."""
+        for assertion in self.rubric:
+            if assertion.startswith("contains:"):
+                needle = assertion[len("contains:"):]
+            elif assertion.startswith("regex:"):
+                needle = assertion[len("regex:"):]
+            else:
+                needle = assertion
+            if not needle:
+                raise ValueError(
+                    f"rubric assertion {assertion!r} has an empty needle/pattern — it matches every "
+                    "output (including errored/empty runs). Use a literal the model must actually emit."
+                )
+        return self
+
     def evaluate(self, final_message: str, counts: dict[str, int] | None = None) -> bool:
         """Return True iff all configured assertions match. counts maps event-count
         name (e.g., 'deny_events') to observed integer count from MetricAccumulator."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -767,6 +767,26 @@ def _skip_live_vllm(request):
         pytest.skip("live_vllm opt-in (set LOCALHARNESS_LIVE_VLLM=1 with a vLLM endpoint up)")
 
 
+def live_target() -> tuple[str, str]:
+    """Single source of truth for the opted-in live (model_id, base_url) — the LOCALHARNESS_LIVE_*
+    env channel. BOTH the preflight fixture (live_endpoint, below) and the tests
+    (test_spine_real_e2e._live_provider) resolve through here, so they provably hit the SAME
+    endpoint/model: no split-brain preflight, and no silent baked default that could test the wrong
+    thing (issue #5). Hard-fails loud when an opted-in run is not pinned to a real target, per the
+    CLAUDE.md 'fail explicitly, never placeholder data' rule.
+    """
+    model = os.environ.get("LOCALHARNESS_LIVE_MODEL")
+    base_url = os.environ.get("LOCALHARNESS_LIVE_BASE_URL")
+    if not model or not base_url:
+        raise RuntimeError(
+            "live tests are opted in (LOCALHARNESS_LIVE_VLLM=1) but the target is not pinned. Set "
+            "BOTH LOCALHARNESS_LIVE_MODEL and LOCALHARNESS_LIVE_BASE_URL to your served model id and "
+            "endpoint, e.g. LOCALHARNESS_LIVE_MODEL=qwen3.6-27b "
+            "LOCALHARNESS_LIVE_BASE_URL=http://localhost:8000/v1"
+        )
+    return (model, base_url)
+
+
 # -----------------------------------------------------------------------------
 # Phase 23 (LIVE-01): reachability preflight for opted-in live runs.
 #
@@ -775,10 +795,11 @@ def _skip_live_vllm(request):
 #      This fires FIRST, so default/network-less CI never reaches this fixture and
 #      can never be reddened by it.
 #   2. REACHABILITY-GATE (this fixture): runs ONLY when the user opted in (env SET).
-#      An unreachable endpoint is then a REAL failure of an explicit request, so it
-#      HARD-FAILS via pytest.fail() — it does NOT skip and does NOT leak a bare
-#      exception. base_url is resolved from the loaded cfg (model-agnostic — never a
-#      baked :8000 literal or model id).
+#      An unreachable endpoint — or a pinned model the endpoint does not serve — is then
+#      a REAL failure of an explicit request, so it HARD-FAILS via pytest.fail(); it does
+#      NOT skip and does NOT leak a bare exception. (model, base_url) resolve from the ONE
+#      source, live_target() (the LOCALHARNESS_LIVE_* env channel) — the same target the
+#      tests hit, never a baked literal or a second, divergent config lookup.
 # -----------------------------------------------------------------------------
 
 
@@ -786,21 +807,27 @@ def _skip_live_vllm(request):
 def live_endpoint():
     import httpx
 
-    from localharness.cli.components_cmd import _build_loader
-
     # ENV-GATE first: this fixture is module-scoped, so it sets up BEFORE the
     # function-scoped _skip_live_vllm autouse gate — without this self-skip it
-    # would call load_harness() and ConfigNotFound-error at setup in default/CI
-    # runs (no ~/.localharness) before the skip could fire.
+    # would resolve the target and error at setup in default/CI runs (no opt-in)
+    # before the skip could fire.
     if not os.environ.get("LOCALHARNESS_LIVE_VLLM"):
         pytest.skip("live_vllm opt-in (set LOCALHARNESS_LIVE_VLLM=1 with a vLLM endpoint up)")
 
-    # Live env channel first (matches test_injection_redteam + _live_provider), else the loaded
-    # config. Module-scoped: runs BEFORE the function-scoped isolation fixture, so load_harness()
-    # here reads the REAL home config — but the env var keeps preflight + tests on one target.
-    base = os.environ.get("LOCALHARNESS_LIVE_BASE_URL") or _build_loader().load_harness().provider.base_url
+    # Resolve the SAME (model, base) the tests hit — single source (issue #5), so the preflight and
+    # the tests can never diverge. live_target() hard-fails loud if the opted-in run is not pinned.
+    model, base = live_target()
     try:
-        httpx.get(base.rstrip("/") + "/models", timeout=3.0).raise_for_status()
+        resp = httpx.get(base.rstrip("/") + "/models", timeout=3.0)
+        resp.raise_for_status()
     except Exception as e:  # noqa: BLE001 — any failure to reach the opted-in endpoint is a hard fail
         pytest.fail(f"LOCALHARNESS_LIVE_VLLM is set but vLLM is unreachable at {base}: {e}")
+    # The pinned model must actually be served — turns the confusing downstream capability-probe
+    # 404 (issue #5 repro) into a clear, actionable preflight failure instead.
+    served = {m.get("id") for m in resp.json().get("data", [])}
+    if model not in served:
+        pytest.fail(
+            f"LOCALHARNESS_LIVE_MODEL={model!r} is not served at {base} (served: {sorted(served)}). "
+            "Set LOCALHARNESS_LIVE_MODEL to a model the endpoint actually serves."
+        )
     return base

--- a/tests/integration/test_spine_real_e2e.py
+++ b/tests/integration/test_spine_real_e2e.py
@@ -29,7 +29,6 @@ SC9 (sealed holdout): every scenario here is slice='train'. The holdout slice is
 """
 from __future__ import annotations
 
-import os
 import pathlib
 
 import pytest
@@ -220,18 +219,21 @@ def _make_train_corpus_repo(path):
     scen_dir.mkdir(parents=True)
     for n in ("noop_01", "noop_02"):
         # A COMPLETE valid ScenarioSpec (minimal name:/slice: stubs are dropped by
-        # _load_scenarios_from_paths). A zero-tool, trivially-satisfiable scenario keeps the
-        # live generation cheap while still driving the real spine.
+        # _load_scenarios_from_paths). A zero-tool scenario keeps the live generation cheap
+        # while still driving the real spine. The rubric is `contains:BENCH_NOOP_OK` (a literal
+        # the prompt tells the model to emit) — NOT the empty-needle `contains:` footgun that
+        # scored even an errored run 1.0 (issue #4): a run that dies before generating leaves an
+        # empty (or `[scenario_error: ...]`) final message that cannot contain the token -> 0.
         (scen_dir / f"{n}.yaml").write_text(
             "\n".join(
                 [
                     f"name: {n}",
                     "slice: train",
                     "category: tool_basics",
-                    "prompt: 'Reply however you like, then end your turn.'",
+                    "prompt: 'Reply with the token BENCH_NOOP_OK and then end your turn.'",
                     "success_criteria:",
                     "  rubric:",
-                    "    - 'contains:'",
+                    "    - 'contains:BENCH_NOOP_OK'",
                     "tools_allowed: []",
                     "budget:",
                     "  max_actions: 1",
@@ -359,19 +361,17 @@ async def test_live_full_loop_holdout_unreached(live_endpoint, tmp_path):
 
 
 def _live_provider() -> tuple[str, str]:
-    """(model_id, base_url) for opted-in live runs — the LOCALHARNESS_LIVE_* env channel.
+    """(model_id, base_url) for opted-in live runs — resolved from the SINGLE source
+    (conftest.live_target), so the preflight fixture and the tests provably hit the same target.
 
-    The autouse _isolate_localharness_home fixture (conftest.py) seeds EVERY test's config
-    with default_model 'test-model', which 404s vLLM's capability probe AND /tokenize — and
-    TokenCounter is server-or-fail by design, so every bench run dies inside
-    _build_agent_loop before a single generation. The env channel (established by
-    test_injection_redteam.py) is the live-run source of truth; the defaults mirror the
-    box reference architecture. Nothing is baked into src/, and env overrides both.
+    Previously this baked `qwen3.6-27b` / `localhost:8000` defaults: with LOCALHARNESS_LIVE_VLLM=1
+    but the model/url env vars unset, a user on a non-default setup silently tested the wrong model
+    (issue #5). live_target() now hard-fails loud when the target is not pinned, so an opted-in run
+    can no longer resolve to a baked default that differs from reality.
     """
-    return (
-        os.environ.get("LOCALHARNESS_LIVE_MODEL", "qwen3.6-27b"),
-        os.environ.get("LOCALHARNESS_LIVE_BASE_URL", "http://localhost:8000/v1"),
-    )
+    from tests.conftest import live_target
+
+    return live_target()
 
 
 def _live_cfg(cfg):
@@ -543,10 +543,22 @@ async def test_live_budget_cap_halts(live_endpoint, tool_scenario_corpus, tmp_pa
         )
         completed = samples[0]
 
-        # THE cap proof: the SECOND step never ran, so the run cannot reach success (success needs
-        # the bash step's executed HELLO_BENCH_OK output to satisfy the rubric). The loop halted at
-        # the cap after at most the first action. Asserted via the ABSENT second-step effect — never
-        # tool_call_count. (A live model that emits a single tool call is still capped at 1 action.)
+        # THE cap proof, causally tied to the cap (issue #3). `success is False` ALONE was vacuous:
+        # any unrelated failure (endpoint down, misconfigured client, scenario error) also makes it
+        # False, so the test passed without the cap ever being exercised. Instead assert EXACTLY one
+        # action was dispatched:
+        #   - an early-erroring run generates NOTHING -> tool_call_count == 0 -> FAILS here (was the
+        #     vacuous pass); the cap loop halts at budget.check (loop.py:129) BEFORE iteration 2, so a
+        #     working ReAct run dispatches exactly one action;
+        #   - an UNCAPPED run would dispatch both steps -> tool_call_count == 2 -> also FAILS here.
+        # This is a valid use of tool_call_count (proving GENERATION happened) — it is only the
+        # "green-check trap" when used to prove dispatch SUCCESS, which we do not.
+        assert completed.tool_call_count == 1, (
+            f"budget cap of 1 must dispatch exactly one action, got {completed.tool_call_count}: "
+            "0 == the run errored before generating (the old vacuous pass), >1 == the cap did not hold"
+        )
+        # And the SECOND step's success-producing side-effect is therefore absent: success needs the
+        # bash step's executed HELLO_BENCH_OK output, which the cap prevented.
         assert completed.success is False, (
             "with max_actions=1 the loop must halt after step 1; the second (bash) step's "
             "success-producing side-effect must be absent"


### PR DESCRIPTION
Closes the three open **live-suite** bugs (#3, #4, #5). They share one disease: the suite could pass **GREEN when the vLLM endpoint was misconfigured and every run errored** — the exact "green test on a lie" documented when filing them.

## The fixes

**#4 — empty-needle rubric scored errored runs 1.0.** `_make_train_corpus_repo`'s gate corpus used `contains:` with an *empty* needle; `"" in text` is always `True`, so a run that died before emitting a token still scored 1.0. Fixed the corpus to a literal the prompt tells the model to emit (`contains:BENCH_NOOP_OK`), **and** added a load-time guard in `SuccessCriteria` that rejects any empty-needle `contains:`/`regex:`/bare rubric — so the footgun can't silently recur in *any* scenario. (Verified: no real scenario uses an empty needle.)

**#3 — budget-cap test passed vacuously.** `test_live_budget_cap_halts` asserted only `success is False`, which any unrelated failure also satisfies (so the cap was never actually exercised — observed in practice). Now asserts **exactly one action dispatched** (`tool_call_count == 1`): an early-erroring run dispatches 0 → RED; an uncapped run dispatches 2 → RED; only a genuinely-capped run passes (second step's side-effect absent).

**#5 — live suite silently used baked defaults / split-brain preflight.** `_live_provider` baked `qwen3.6-27b`/`localhost:8000`, while the `live_endpoint` preflight resolved `base_url` from a *different* source (loaded home cfg) — so an opted-in run could silently test the wrong model or probe a different endpoint than it hit. Added a single-source resolver `live_target()` (`LOCALHARNESS_LIVE_*` env) used by **both**; it hard-fails loud when unpinned, and the preflight now verifies the pinned model is actually served (clear "set `LOCALHARNESS_LIVE_MODEL`" instead of a confusing downstream 404).

## Verification (both directions, against a live `qwen3.6-27b` endpoint)

| Scenario | Result |
|---|---|
| Full live suite, correctly pinned | **6/6 pass** |
| Wrong model (`LOCALHARNESS_LIVE_MODEL=not-a-real-model`) | preflight **fails loud**: `…not served at … (served: ['qwen3.6-27b'])` |
| Unpinned (`LOCALHARNESS_LIVE_VLLM=1` only) | **fails loud**: `RuntimeError: …target is not pinned. Set…` |
| Errored-run scoring (`""` and `[scenario_error: …]`) | old empty needle → `True` (vacuous); new rubric → `False` (RED) |
| Full **non-live** suite | **1241 passed**, 0 failed |

## Honest scope note

`test_live_full_loop_holdout_unreached`'s assertions are deliberately **structural** (the gate routed to the `train` slice and *never constructed* the sealed `holdout` slice) and hold regardless of generation outcome — that is the point of the holdout-seal proof, not a rubric bug. The vacuous-pass fix targets the two tests whose assertions were *outcome*-dependent (`budget_cap`, `divergence`) plus the root-cause rubric guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)