### PR TITLE
fix: clear the 20 test-suite warnings at their source

### DIFF
--- a/src/localharness/bench/aggregator.py
+++ b/src/localharness/bench/aggregator.py
@@ -7,6 +7,7 @@ Wilson score interval is closed-form and computed inline. numpy provides percent
 from __future__ import annotations
 
 import math
+import warnings
 from dataclasses import dataclass
 from typing import Any
 
@@ -80,6 +81,40 @@ def wilson_ci_95(successes: int, n: int) -> ProportionCI:
 # Welch's t-test (A/B early-stop in bench compare)
 # -------------------------------------------------------------------------
 
+def _welch(first: list[float], second: list[float], **kwargs: Any) -> tuple[float, float]:
+    """``stats.ttest_ind`` (Welch) with the zero-variance degenerate case handled explicitly.
+
+    Two things are wrong with calling scipy bare here, and both are about NOT letting a
+    numerical edge case decide a promotion silently:
+
+    1. scipy emits a catastrophic-cancellation RuntimeWarning whenever an arm's variance is at
+       or near zero. In THIS harness that is routine, not an accident: a success_rate slice
+       where every fixture scores the same is an ordinary outcome. Left unhandled the warning
+       sprays onto the stderr of a running bench (and every test that exercises the gate), where
+       it reads like a fault. It is informational — the statistic scipy returns is unchanged —
+       so it is contained at the one call site that provokes it.
+    2. A fully degenerate pair (both arms constant AND equal) makes the t-statistic 0/0 -> nan.
+       Every downstream ``p < alpha`` against nan is False, so the verdict — no evidence of a
+       difference — happens to be right, but only by inheriting NaN comparison semantics. State
+       it instead: nan collapses to ``(0.0, 1.0)``.
+
+    NOT normalized: two constant arms with DIFFERENT means still yield ``t=inf, p=0.0`` from
+    scipy, i.e. certainty from arms that contain no within-arm information at all. That is
+    pre-existing gate behavior (``_IMPROVED_TRAIN_*`` in the experiment tests promotes on it),
+    so it is left alone here rather than changed under cover of a warning fix.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Precision loss occurred in moment calculation",
+            category=RuntimeWarning,
+        )
+        t_stat, p_value = stats.ttest_ind(first, second, **kwargs)
+    if math.isnan(p_value):
+        return (0.0, 1.0)
+    return (float(t_stat), float(p_value))
+
+
 def welch_ab_test(baseline: list[float], head: list[float], alpha: float = 0.05) -> tuple[float, float, bool]:
     """Welch's t-test for A/B comparison. Returns (t_stat, p_value, regressed).
 
@@ -89,9 +124,9 @@ def welch_ab_test(baseline: list[float], head: list[float], alpha: float = 0.05)
     """
     if len(baseline) < 2 or len(head) < 2:
         return (0.0, 1.0, False)  # insufficient data — never flag regression
-    t_stat, p_value = stats.ttest_ind(head, baseline, equal_var=False)
+    t_stat, p_value = _welch(head, baseline, equal_var=False)
     regressed = bool(np.mean(head) > np.mean(baseline)) and bool(p_value < alpha)
-    return (float(t_stat), float(p_value), regressed)
+    return (t_stat, p_value, regressed)
 
 
 def welch_improvement(baseline: list[float], head: list[float], alpha: float = 0.05) -> tuple[float, float, bool]:
@@ -109,8 +144,8 @@ def welch_improvement(baseline: list[float], head: list[float], alpha: float = 0
     """
     if len(baseline) < 2 or len(head) < 2:
         return (0.0, 1.0, False)
-    t_stat, p_value = stats.ttest_ind(head, baseline, equal_var=False, alternative="greater")
-    return (float(t_stat), float(p_value), bool(p_value < alpha))
+    t_stat, p_value = _welch(head, baseline, equal_var=False, alternative="greater")
+    return (t_stat, p_value, bool(p_value < alpha))
 
 
 def welch_regression(baseline: list[float], head: list[float], alpha: float) -> bool:
@@ -123,7 +158,7 @@ def welch_regression(baseline: list[float], head: list[float], alpha: float) -> 
     """
     if len(baseline) < 2 or len(head) < 2:
         return False
-    _t, p_value = stats.ttest_ind(baseline, head, equal_var=False, alternative="greater")
+    _t, p_value = _welch(baseline, head, equal_var=False, alternative="greater")
     return bool(p_value < alpha)
 
 

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -952,7 +952,7 @@ async def test_tool_call_action_published_before_observation(mock_llm_client, bu
 # Task 2: Memory loader tiered prompt tests
 # ---------------------------------------------------------------------------
 
-from unittest.mock import AsyncMock as _AsyncMock
+from unittest.mock import AsyncMock as _AsyncMock, MagicMock as _MagicMock
 from dataclasses import dataclass as _dataclass
 
 
@@ -963,6 +963,21 @@ class _MockMemoryContext:
     guardrails_md: str
     fact_count: int
     token_estimate: int
+
+
+def _mock_memory_loader(**load_context_kwargs):
+    """A memory-loader double shaped like the REAL MemoryStore: an async ``load_context`` on an
+    otherwise SYNCHRONOUS object.
+
+    Deliberately NOT a bare AsyncMock. On one of those every attribute is async, including
+    ``set_current_session`` — which MemoryStore defines as a plain ``def`` and loop.py therefore
+    calls without awaiting. The bare mock turned that call into an orphaned coroutine (a
+    'never awaited' RuntimeWarning), and worse, it made the mock incapable of catching the
+    inverse bug: production switching a sync memory call to async would still pass here.
+    """
+    loader = _MagicMock()
+    loader.load_context = _AsyncMock(**load_context_kwargs)
+    return loader
 
 
 def _make_memory_agent_loop(memory_loader=None):
@@ -990,8 +1005,7 @@ def _make_memory_agent_loop(memory_loader=None):
 @pytest.mark.asyncio
 async def test_memory_loader_tiered_prompt():
     """MEM-03: load_context() result builds tiered system prompt with all 3 sections."""
-    memory = _AsyncMock()
-    memory.load_context = _AsyncMock(return_value=_MockMemoryContext(
+    memory = _mock_memory_loader(return_value=_MockMemoryContext(
         agent_memory_md="my notes",
         division_md="div context",
         guardrails_md="safety rules",
@@ -1029,8 +1043,7 @@ async def test_memory_loader_tiered_prompt():
 @pytest.mark.asyncio
 async def test_memory_loader_empty_tiers_omitted():
     """MEM-03: Empty tiers silently omitted -- no empty ## headings."""
-    memory = _AsyncMock()
-    memory.load_context = _AsyncMock(return_value=_MockMemoryContext(
+    memory = _mock_memory_loader(return_value=_MockMemoryContext(
         agent_memory_md="notes only",
         division_md="",
         guardrails_md="",
@@ -1061,8 +1074,7 @@ async def test_memory_loader_empty_tiers_omitted():
 @pytest.mark.asyncio
 async def test_memory_loader_failure_nonfatal():
     """MEM-03: Memory load failure is non-fatal -- agent runs with base role only."""
-    memory = _AsyncMock()
-    memory.load_context = _AsyncMock(side_effect=RuntimeError("db gone"))
+    memory = _mock_memory_loader(side_effect=RuntimeError("db gone"))
 
     loop, llm = _make_memory_agent_loop(memory_loader=memory)
 

--- a/tests/unit/test_start_cmd.py
+++ b/tests/unit/test_start_cmd.py
@@ -33,6 +33,22 @@ def _make_mock_orchestrator():
     return mock
 
 
+def _make_mock_agent_loop():
+    """Agent-loop double for the OrchestratorREPL routing tests.
+
+    ``_llm = None`` is the point of the helper. ``run()`` always fires the best-effort /model
+    prefetch, which reads ``_llm.config.base_url`` and hands it to ``model_ops.list_live_models``
+    in a worker thread. On a bare AsyncMock that attribute is itself an AsyncMock, so the
+    ``base_url.rstrip('/')`` inside the probe returns a coroutine nobody awaits (a 'never
+    awaited' RuntimeWarning) and the probe then goes out over httpx to a URL built from a
+    mock's repr. None is the no-LLM shape ``_prefetch_model_cache`` already short-circuits on,
+    which is honest for tests about input routing rather than the model picker.
+    """
+    loop = AsyncMock()
+    loop._llm = None
+    return loop
+
+
 # ---------------------------------------------------------------------------
 # app.py registration
 # ---------------------------------------------------------------------------
@@ -173,7 +189,7 @@ def test_repl_slash_help():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_bus = AsyncMock()
     mock_orch = _make_mock_orchestrator()
 
@@ -192,7 +208,7 @@ def test_repl_slash_quit_raises_eof():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = AsyncMock(return_value="/quit")
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_bus = AsyncMock()
     mock_orch = _make_mock_orchestrator()
 
@@ -210,7 +226,7 @@ def test_repl_slash_exit_raises_eof():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = AsyncMock(return_value="/exit")
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_bus = AsyncMock()
     mock_orch = _make_mock_orchestrator()
 
@@ -236,7 +252,7 @@ def test_repl_slash_agents_empty():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_bus = AsyncMock()
     mock_orch = _make_mock_orchestrator()
 
@@ -267,7 +283,7 @@ def test_repl_slash_agents_with_cards():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_bus = AsyncMock()
     mock_orch = _make_mock_orchestrator()
     mock_orch._card_registry.all_cards.return_value = [mock_card]
@@ -299,7 +315,7 @@ def test_repl_unknown_slash_rejected_deterministically():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_loop._config = mock_agent_config
     mock_loop.current_session_id = None
     mock_loop.run_turn = AsyncMock(return_value="Done.")
@@ -339,7 +355,7 @@ def test_repl_normal_input_routes_to_agent():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_loop._config = mock_agent_config
     mock_loop.current_session_id = None
     mock_loop.run_turn = AsyncMock(return_value="Done.")
@@ -376,7 +392,7 @@ def test_repl_does_not_double_fire_output():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_loop._config = mock_agent_config
     mock_loop.current_session_id = None
     mock_loop.run_turn = AsyncMock(return_value="Done.")
@@ -409,7 +425,7 @@ def test_repl_skips_empty_input():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_bus = AsyncMock()
     mock_orch = _make_mock_orchestrator()
 
@@ -425,7 +441,7 @@ def test_repl_exits_on_eof():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = AsyncMock(side_effect=EOFError)
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_bus = AsyncMock()
     mock_orch = _make_mock_orchestrator()
 
@@ -454,7 +470,7 @@ def test_repl_creation_intent_starts_workflow():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_bus = AsyncMock()
     mock_orch = _make_mock_orchestrator()
 
@@ -494,7 +510,7 @@ def test_repl_active_workflow_routes_to_creation_handler():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_bus = AsyncMock()
     mock_orch = _make_mock_orchestrator()
 
@@ -580,7 +596,7 @@ def test_repl_creation_cancel_clears_workflow():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_bus = AsyncMock()
     mock_orch = _make_mock_orchestrator()
 
@@ -715,7 +731,7 @@ def test_repl_publishes_user_message_before_run_turn():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_loop._config = mock_agent_config
     mock_loop.current_session_id = None
     mock_loop.run_turn = AsyncMock(return_value="Done.")
@@ -754,7 +770,7 @@ def test_repl_slash_commands_no_user_message():
 
     mock_channel = AsyncMock()
     mock_channel.read_input = fake_read_input
-    mock_loop = AsyncMock()
+    mock_loop = _make_mock_agent_loop()
     mock_bus = AsyncMock()
     mock_orch = _make_mock_orchestrator()
 


### PR DESCRIPTION
The suite was green but emitting 20 warnings. Three unrelated causes, each fixed where it originates rather than filtered out of pytest's view.

## 1. scipy catastrophic-cancellation — 14 warnings

`bench/aggregator.py` called `stats.ttest_ind` bare. Zero-variance arms are **routine** in this harness — a `success_rate` slice where every fixture scores the same is an ordinary outcome, not a numerical accident — so this was firing during normal operation and spraying onto the stderr of a running bench, where it reads like a fault.

A `_welch` wrapper contains the warning at the one provoking call site. It also stops the fully degenerate case being decided by NaN semantics: both arms constant and equal gives `0/0 -> nan`, and the resulting "no evidence of a difference" verdict was previously an accident of `nan < alpha` being False. That is now stated as `p=1.0`. No other behavior changes.

## 2 & 3. Never-awaited coroutines — 6 warnings

Both were bare `AsyncMock`s standing in for objects with **synchronous** methods — so besides the warning, neither mock could have caught the inverse bug (production switching a sync call to async would still have passed).

- **`test_agent_loop.py` memory tests.** `MemoryStore.set_current_session` is a plain `def`, so `loop.py` calls it unawaited — against an `AsyncMock` that turned the call into an orphaned coroutine. Now a `MagicMock` carrying an async `load_context`, which is the real store's shape.
- **`test_start_cmd.py` REPL tests.** `run()` always fires the best-effort `/model` prefetch, which reads `_llm.config.base_url` off the mock. `base_url.rstrip('/')` returned a coroutine, and the probe then made a real `httpx` call to a URL built from a mock's repr, in a worker thread. All 15 REPL mock loops now go through `_make_mock_agent_loop()` with `_llm = None`, the no-LLM shape `_prefetch_model_cache` already short-circuits on.

## Deliberately not changed

`welch_improvement` still returns `p=0.0` for two constant arms with different means (`t=inf`) — infinite confidence from arms carrying no within-arm information. `_IMPROVED_TRAIN_*` depends on that promoting, and `test_bonferroni_alpha_scaling` already comments around the same effect, so changing it is a real change to the gate's semantics, not a warning cleanup. It is documented in the `_welch` docstring instead.

**Worth a second opinion** — if you want the gate to refuse infinite-confidence verdicts, that is a separate change with test fixtures to revisit.

## Verification

- `2638 passed, 17 skipped, 4 xfailed` — **0 warnings** (was 20).
- `ruff` on the two touched test files reports byte-for-byte identical findings before and after (36 pre-existing `E402`/`F401`/`F811`/etc.); `aggregator.py` is clean.
- `mypy` on `aggregator.py` reports only the pre-existing missing-`scipy`-stubs error on an untouched import line.

One unrelated observation: `test_start_cmd.py::test_hard_fail_in_resource_window_process_exits_not_hangs` failed once under `PYTHONTRACEMALLOC=30` and passed in every untraced run — looks timing-sensitive and independent of these changes, but may be worth watching.

---
[Warp conversation](https://app.warp.dev/conversation/c2df62ed-4a9c-4662-a390-8c8aed29d980)

Co-Authored-By: Warp <agent@warp.dev>
