### PR TITLE
feat(cli): session-only --model override, --list-models, and HF --download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to LocalHarness are documented here. The format follows
 ## [Unreleased]
 
 ### Added
+- `localharness start --model <name>`/`-m`: a session-only model override that
+  is never persisted to config.yaml. Restricted to a model already being
+  served — an attach-only provider (Ollama/LM Studio) can pick any live
+  model, but a harness-managed single-model server (llama.cpp/vLLM) errors
+  out rather than hot-switching, pointing at `localharness model <name>`
+  (persist + restart) or the REPL `/model` command instead.
+- `localharness start --list-models`: lists live-served and configured models
+  and exits, without loading agents or starting a session.
+- `localharness model --download <repo_id>` (optionally `--file <name>`):
+  standalone Hugging Face download, independent of `init`'s guided vLLM
+  setup. `--file` fetches exactly one sibling file — the correct way to pull
+  a single GGUF quant out of a repo that ships several — instead of the
+  whole-repo snapshot `--download` alone performs.
 - **`doctor` warns when an AMD GPU is paired with a Vulkan-linked llama.cpp binary**
   (#144, #148 — contributed by @mjdufresne, verified on real AMD hardware). llama.cpp's
   cmake quietly prefers Vulkan when the SDK is present, and `-ngl` offloads onto the GPU

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ uv run localharness init    # probes vLLM :8081/:8000, Ollama :11434, LM Studio 
 uv run localharness start   # interactive session
 ```
 
-`init` detects your endpoint and models, probes tool-calling capability, and writes `~/.localharness/config.yaml`. No server running? `init` walks you through setup: pick your hardware (reference architecture) and it provisions the local server (pulling the vLLM container where Docker is available) — `start` then reuses it. Inside the REPL, `/model` lists served + downloaded models and swaps between them. Non-standard setup: `localharness init --endpoint http://host:port/v1`. A repo-local `.localharness/` directory overlays the global config.
+`init` detects your endpoint and models, probes tool-calling capability, and writes `~/.localharness/config.yaml`. No server running? `init` walks you through setup: pick your hardware (reference architecture) and it provisions the local server (pulling the vLLM container where Docker is available) — `start` then reuses it. Inside the REPL, `/model` lists served + downloaded models and swaps between them; `localharness start --model <name>` picks one for a single session without touching config, and `--list-models` lists without starting a session. `localharness model --download <repo_id>` (optionally `--file <name>` for one GGUF quant out of a multi-quant repo) pulls a model from Hugging Face ahead of time. Non-standard setup: `localharness init --endpoint http://host:port/v1`. A repo-local `.localharness/` directory overlays the global config.
 
 > Got it running? If LocalHarness saved you an API bill, a [star](https://github.com/ahwurm/localharness/stargazers) helps other local-LLM folks find it.
 
@@ -140,11 +140,11 @@ share a machine. A laptop can run agents against a model served elsewhere on you
 | Command | Purpose |
 |---------|---------|
 | `init` | Detect endpoint/model, write config |
-| `start` | Interactive session |
+| `start` | Interactive session (`--model`/`-m` for a one-off session model, `--list-models` to list and exit) |
 | `doctor` | Diagnose config/endpoint issues |
 | `config migrate` | Fold new shipped security defaults into an existing config — also auto-applied on the first `start` after an upgrade (revision-stamped, additive, backed up) |
 | `validate` | Validate agent/org YAML |
-| `model` | List served/downloaded models, or switch the persisted default |
+| `model` | List served/downloaded models, switch the persisted default, or `--download <repo_id>` (optionally `--file <name>`) a model from Hugging Face |
 | `agent …` | Manage agent definitions |
 | `bench …` | Run the scenario benchmark |
 | `components …` | Autoresearch component registry |

--- a/docs/runtimes/llamacpp.md
+++ b/docs/runtimes/llamacpp.md
@@ -68,6 +68,21 @@ llama-server -m <model.gguf> --host 127.0.0.1 --port 8080 --jinja -c 32768 -ngl 
 OpenAI-compatible surface at `http://127.0.0.1:8080/v1`; native `/props` reports `n_ctx`, native
 `/tokenize` gives exact token counts.
 
+### Downloading a GGUF from Hugging Face
+
+A GGUF repo commonly ships several quantizations as sibling files in the SAME repo (e.g.
+`Q4_K_M.gguf`, `Q8_0.gguf`) — `localharness model --download <repo_id>` alone pulls the whole
+repo snapshot, every quant included. Name the one file you actually want with `--file`:
+
+```bash
+localharness model --download Qwen/Qwen3.6-35B-A3B-GGUF --file Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
+```
+
+This lands the file in the standard HF cache and prints its local path — point `server.model` /
+`-m` at that path. The download is standalone (no server or config required); it does not
+restart a running managed server or change `provider.default_model` — update `server.model` in
+config.yaml (or `localharness model <path>`, once it's being served) yourself afterward.
+
 **Load-bearing gotcha:** recent `llama-server` builds default to multiple parallel slots and
 silently divide `-c` among them (e.g. `-c 32768` across 4 slots = an 8k window per request). The
 harness is single-stream — pass `--parallel 1` so one slot owns the whole context. `init`/`doctor`

--- a/src/localharness/cli/model_cmd.py
+++ b/src/localharness/cli/model_cmd.py
@@ -22,6 +22,33 @@ console = Console()
 err_console = Console(stderr=True)
 
 
+def _download(repo_id: str, filename: Optional[str]) -> None:
+    """`localharness model --download <repo_id> [--file <name>]` — standalone HF fetch, no
+    running server / config required (unlike `init`'s guided-setup download, which is tied to
+    the vLLM install flow). Whole-repo snapshot by default; --file fetches exactly one sibling
+    file (the GGUF case, where a repo ships several quantizations side by side)."""
+    from localharness.provider import server as managed_server
+
+    try:
+        if filename:
+            console.print(f"Downloading {filename!r} from {repo_id}...")
+            path = managed_server.download_file(repo_id, filename)
+        else:
+            console.print(f"Downloading {repo_id} (full snapshot)...")
+            path = managed_server.download_model(repo_id)
+    except Exception as exc:
+        err_console.print(f"[bold red]Error:[/bold red] download failed: {exc}")
+        raise typer.Exit(2)
+
+    console.print(f"[green]✓[/green] Downloaded to {path}")
+    console.print(
+        "To use it: point a llama.cpp profile's `server.model` at this path in config.yaml "
+        "(single-model managed server), or run `localharness model "
+        f"{path}`" + ("" if filename else f" or `localharness model {repo_id}`") +
+        " once it's being served, to set it as the default."
+    )
+
+
 def model(
     name: Optional[str] = typer.Argument(
         None,
@@ -36,8 +63,28 @@ def model(
         "else ~/.localharness). Parity with `start`/`doctor`/`validate`; the persisted "
         "overlay is written HERE.",
     ),
+    download: Optional[str] = typer.Option(
+        None,
+        "--download",
+        help="Download a Hugging Face repo id into the local HF cache, then exit "
+        "(does not change the configured default — follow up with `localharness model <path>`).",
+    ),
+    file: Optional[str] = typer.Option(
+        None,
+        "--file",
+        help="With --download: fetch only this ONE filename from the repo (a specific GGUF "
+        "quant, e.g. `Qwen3-32B-Q4_K_M.gguf`) instead of the whole repo snapshot. Use this for "
+        "llama.cpp models — GGUF repos commonly ship several quantizations as sibling files.",
+    ),
 ) -> None:
     """List available models, or switch the persisted default with `localharness model <name>`."""
+    if download is not None:
+        _download(download, file)
+        return
+    if file is not None:
+        err_console.print("[bold red]Error:[/bold red] --file requires --download <repo_id>.")
+        raise typer.Exit(2)
+
     # config_dir=None routes through the resolver's env/default chain (#35); an explicit flag or
     # LOCALHARNESS_DIR isolates the overlay to that dir.
     loader = ConfigLoader(config_dir=config_dir)

--- a/src/localharness/cli/start_cmd.py
+++ b/src/localharness/cli/start_cmd.py
@@ -303,7 +303,8 @@ def _auto_migrate_deny_defaults(config_file: Path) -> None:
 
 
 async def _start_async(agent_name: str | None, verbose: bool, debug: bool, config_dir: str,
-                       channel_mode: str = "terminal", subagents: bool = False) -> None:
+                       channel_mode: str = "terminal", subagents: bool = False,
+                       model_override: str | None = None, list_models: bool = False) -> None:
     """Async entry point: discover agent, wire dependencies, run REPL."""
     import time as _time
     import uuid
@@ -347,6 +348,41 @@ async def _start_async(agent_name: str | None, verbose: bool, debug: bool, confi
     except Exception as exc:
         err_console.print(f"[bold red]Error:[/bold red] Cannot load config: {exc}")
         raise typer.Exit(1)
+
+    # --list-models: a lightweight, config-only path — reuses the same live-probe `localharness
+    # model` (bare) uses, exposed on `start` too since that's the command most people reach for
+    # first. Never loads agents / starts a session.
+    if list_models:
+        from localharness.cli import model_ops
+        provider = harness.provider
+        try:
+            live, reachable = model_ops.list_live_models(provider.base_url)
+        except model_ops.MalformedModelListError as exc:
+            err_console.print(
+                f"[bold red]Error:[/bold red] the server at {provider.base_url} responded, but "
+                f"the response wasn't understood ({exc})"
+            )
+            raise typer.Exit(2)
+        configured_only = [m for m in provider.available_models if m not in live]
+        if not reachable and not configured_only:
+            err_console.print(
+                f"[bold red]Error:[/bold red] could not reach {provider.base_url} and no "
+                "configured models were found. Is the server running?"
+            )
+            raise typer.Exit(2)
+        console.print("Models:")
+        for m in live:
+            mark = "  [active]" if m == provider.default_model else ""
+            console.print(f"  {m}  (serving){mark}", markup=False)
+        for m in configured_only:
+            console.print(f"  {m}  (configured, not currently served)", markup=False)
+        if not live and not configured_only:
+            console.print("  (none)")
+        console.print(
+            "\nUse `localharness start --model <name>` for a one-off session, or "
+            "`localharness model <name>` to persist a new default."
+        )
+        raise typer.Exit(0)
 
     _ensure_packaged_tools(cfg_path)
 
@@ -446,6 +482,38 @@ async def _start_async(agent_name: str | None, verbose: bool, debug: bool, confi
         if agent_config.model != "inherit"
         else provider.default_model
     )
+    if model_override:
+        # --model (session-only, never persisted): restricted to a model ALREADY being served.
+        # A harness-managed single-model server (llama.cpp/vLLM) serves exactly one checkpoint at
+        # a time; switching it means a restart, which `localharness model <name>` (persist +
+        # restart) or the REPL `/model` command (live restart) already handle deliberately — this
+        # flag must NOT trigger that, so it only accepts the model the managed server already
+        # serves. An attach-only provider (Ollama/LM Studio) can serve several models at once, so
+        # any already-live model is fair game.
+        from localharness.cli import model_ops
+        try:
+            _live, _reachable = model_ops.list_live_models(provider.base_url)
+        except model_ops.MalformedModelListError as exc:
+            err_console.print(
+                f"[bold red]Error:[/bold red] the server at {provider.base_url} responded, but "
+                f"the response wasn't understood ({exc})"
+            )
+            raise typer.Exit(1)
+        _choices = _live or list(provider.available_models)
+        if model_override not in _choices:
+            avail_hint = f" Available: {', '.join(_choices)}." if _choices else ""
+            err_console.print(
+                f"[bold red]Error:[/bold red] --model {model_override!r} is not currently "
+                f"served at {provider.base_url}.{avail_hint}"
+            )
+            if harness.server is not None:
+                err_console.print(
+                    "This is a harness-managed single-model server — switching models restarts "
+                    "it. Use `localharness model <name>` to persist + restart, or the REPL "
+                    "`/model <name>` command for a live restart."
+                )
+            raise typer.Exit(1)
+        resolved_model = model_override
     # Build initial client for the probe (tool_call_mode will be overwritten by probe result).
     _initial_cfg = LLMConfig(
         base_url=provider.base_url,
@@ -1213,9 +1281,11 @@ def start_app(
     config_dir: Annotated[str, typer.Option("--config-dir", envvar="LOCALHARNESS_DIR")] = "~/.localharness",
     channel: Annotated[str, typer.Option("--channel", "-c", help="Input channel: terminal (default) or discord")] = "terminal",
     subagents: Annotated[bool, typer.Option("--subagents", help="Show the agent picker on startup when multiple agents are configured")] = False,
+    model: Annotated[str | None, typer.Option("--model", "-m", help="Use this model for THIS session only (never persisted). Must already be served — a harness-managed single-model server (llama.cpp/vLLM) cannot be hot-switched this way; use `localharness model <name>` or the REPL `/model` command instead.")] = None,
+    list_models: Annotated[bool, typer.Option("--list-models", help="List models available at the configured provider, then exit")] = False,
 ) -> None:
     """Launch the agent REPL. Zero to chatting in one command."""
     try:
-        asyncio.run(_start_async(agent, verbose, debug, config_dir, channel, subagents))
+        asyncio.run(_start_async(agent, verbose, debug, config_dir, channel, subagents, model, list_models))
     except KeyboardInterrupt:
         console.print("\nGoodbye.")

--- a/src/localharness/provider/server.py
+++ b/src/localharness/provider/server.py
@@ -118,10 +118,26 @@ def is_model_cached(repo_id: str) -> bool:
 
 
 def download_model(repo_id: str) -> str:
-    """Download a checkpoint into the HF cache (tqdm progress). Raises on failure."""
+    """Download a checkpoint into the HF cache (tqdm progress). Raises on failure.
+
+    Pulls the WHOLE repo snapshot — right for a vLLM/transformers-format checkpoint (many
+    shard files, all needed). Wrong for a GGUF repo, which typically ships several quant
+    variants as siblings; use `download_file` for those instead."""
     from huggingface_hub import snapshot_download
 
     return snapshot_download(repo_id)
+
+
+def download_file(repo_id: str, filename: str) -> str:
+    """Download ONE file from a HF repo into the HF cache (tqdm progress). Raises on failure.
+
+    The llama.cpp/GGUF case: a GGUF repo commonly ships several quantizations as sibling files
+    (e.g. `Q4_K_M.gguf`, `Q8_0.gguf`) in the SAME repo — `download_model`'s whole-repo
+    `snapshot_download` would pull every one of them. `hf_hub_download` fetches exactly the
+    named file, returning its local cache path (ready to hand to a `server.model`/`-m` flag)."""
+    from huggingface_hub import hf_hub_download
+
+    return hf_hub_download(repo_id=repo_id, filename=filename)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_model_cmd.py
+++ b/tests/unit/test_model_cmd.py
@@ -388,3 +388,88 @@ def test_model_cli_warns_on_pinned_agent(components_home, monkeypatch):
     result = runner.invoke(app, ["model", "model-b"])
     assert result.exit_code == 0, result.output
     assert "pinned-agent" in result.output and "some-pinned-model" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --download / --file: standalone Hugging Face download routing. huggingface_hub itself is
+# never invoked in these tests — provider.server's download_model/download_file (the ONLY
+# boundary that would reach the network) is mocked, so CI never touches the network. No
+# config or running server is required (the download path runs before ConfigLoader).
+# ---------------------------------------------------------------------------
+
+def test_model_download_full_snapshot_without_file(monkeypatch):
+    """--download alone pulls the whole repo snapshot via download_model, not download_file."""
+    from localharness.provider import server as managed_server
+
+    snapshot_calls: list[str] = []
+    file_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        managed_server, "download_model",
+        lambda repo_id: snapshot_calls.append(repo_id) or f"/fake/cache/{repo_id}",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        managed_server, "download_file",
+        lambda repo_id, filename: file_calls.append((repo_id, filename)),
+        raising=False,
+    )
+
+    result = runner.invoke(app, ["model", "--download", "org/repo"])
+
+    assert result.exit_code == 0, result.output
+    assert snapshot_calls == ["org/repo"]
+    assert file_calls == [], "whole-repo download must not touch the single-file path"
+    assert "/fake/cache/org/repo" in result.output
+
+
+def test_model_download_with_file_fetches_one_sibling(monkeypatch):
+    """--download with --file fetches exactly ONE sibling file via download_file — not the
+    whole-repo snapshot — the correct way to grab a single GGUF quant out of a multi-quant repo."""
+    from localharness.provider import server as managed_server
+
+    snapshot_calls: list[str] = []
+    file_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        managed_server, "download_model",
+        lambda repo_id: snapshot_calls.append(repo_id),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        managed_server, "download_file",
+        lambda repo_id, filename: file_calls.append((repo_id, filename))
+        or f"/fake/cache/{filename}",
+        raising=False,
+    )
+
+    result = runner.invoke(
+        app, ["model", "--download", "org/gguf-repo", "--file", "model-Q4_K_M.gguf"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert file_calls == [("org/gguf-repo", "model-Q4_K_M.gguf")]
+    assert snapshot_calls == [], "the whole-repo snapshot_download path must not run with --file"
+    assert "/fake/cache/model-Q4_K_M.gguf" in result.output
+
+
+def test_model_file_alone_without_download_errors():
+    """--file with no --download is a usage error, not a silent no-op or a switch attempt."""
+    result = runner.invoke(app, ["model", "--file", "model-Q4_K_M.gguf"])
+    assert result.exit_code == 2, result.output
+    assert "--download" in result.output
+
+
+def test_model_download_failure_reported_not_swallowed(monkeypatch):
+    """A download failure (bad repo id, network error inside huggingface_hub) surfaces as an
+    error exit, never a silent success."""
+    from localharness.provider import server as managed_server
+
+    monkeypatch.setattr(
+        managed_server, "download_model",
+        lambda repo_id: (_ for _ in ()).throw(RuntimeError("repo not found")),
+        raising=False,
+    )
+
+    result = runner.invoke(app, ["model", "--download", "org/does-not-exist"])
+
+    assert result.exit_code == 2, result.output
+    assert "repo not found" in result.output

--- a/tests/unit/test_start_cmd.py
+++ b/tests/unit/test_start_cmd.py
@@ -2706,3 +2706,232 @@ async def test_start_guard_error_names_the_pin_that_actually_governs(tmp_path, m
 
     joined = "\n".join(errs)
     assert "model_context_overrides['pinned-model']" in joined
+
+
+# ===========================================================================================
+# --model / --list-models: session-only model selection on `start` (PR #146). --model is
+# restricted to a model ALREADY being served — freely on an attach-only provider (Ollama/LM
+# Studio, several models resident at once), but a harness-managed single-model server
+# (llama.cpp/vLLM) refuses to hot-switch (never auto-restarts) and points at the two
+# mechanisms that DO: `localharness model <name>` (persist + restart) and the REPL `/model`
+# command (live restart). --list-models is a read-only, config-only path with no side effects.
+# ===========================================================================================
+
+def _fake_live_models(models, reachable=True):
+    return lambda *a, **k: (list(models), reachable)
+
+
+async def test_model_override_accepts_served_model(tmp_path, monkeypatch):
+    """--model picks a model already live-served: the session proceeds using it, and — the
+    PR's core guarantee — config.yaml is never touched (session-only, unlike `localharness
+    model`'s persisted switch)."""
+    from localharness.cli import model_ops
+    from localharness.cli.start_cmd import _start_async
+    from localharness.provider.client import LLMClient
+
+    _stub_start_boundaries(tmp_path, monkeypatch)  # ollama, attach-only, default_model=test-model
+    monkeypatch.setattr(
+        model_ops, "list_live_models",
+        _fake_live_models(["test-model", "alt-model"]), raising=False,
+    )
+
+    seen: list = []
+    real_init = LLMClient.__init__
+
+    def spy_init(self, config, *a, **k):
+        seen.append(config)
+        return real_init(self, config, *a, **k)
+    monkeypatch.setattr(LLMClient, "__init__", spy_init)
+
+    await _start_async(None, False, False, str(tmp_path), model_override="alt-model")
+
+    live = [c for c in seen if c.provider_type]  # the session client, not the bare probe client
+    assert live, "no LLMClient was built with the provider type"
+    assert all(c.model == "alt-model" for c in live), [c.model for c in live]
+    # session-only: --model must never touch provider.default_model on disk (unlike
+    # `localharness model <name>`'s persisted switch). The deny-defaults auto-migration may
+    # still legitimately rewrite the permissions block, so assert on the provider fields
+    # specifically rather than byte-for-byte file equality.
+    config_after = (tmp_path / "config.yaml").read_text()
+    assert "default_model: test-model" in config_after
+    assert "alt-model" not in config_after, \
+        "--model must be session-only — the override must never be written to config.yaml"
+
+
+async def test_model_override_attach_only_free_pick(tmp_path, monkeypatch):
+    """An attach-only provider (Ollama/LM Studio — no harness-managed server) can pick ANY
+    live-served model freely, even one that differs from the configured default."""
+    from localharness.cli import model_ops
+    from localharness.cli.start_cmd import _start_async
+
+    _stub_start_boundaries(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        model_ops, "list_live_models",
+        _fake_live_models(["test-model", "second-model", "third-model"]), raising=False,
+    )
+
+    await _start_async(None, False, False, str(tmp_path), model_override="third-model")
+
+    rows = _read_sessions(tmp_path)
+    assert len(rows) == 1 and rows[0][3] == "complete"
+
+
+async def test_model_override_rejects_unserved_on_managed_server(tmp_path, monkeypatch):
+    """The PR's main safety behavior: a harness-managed single-model server (llama.cpp/vLLM)
+    serves exactly one checkpoint — --model must refuse to switch it (never auto-restart) and
+    the error must hint at the two mechanisms that DO switch it."""
+    import typer
+    from localharness.cli import model_ops
+    from localharness.cli.start_cmd import _start_async
+
+    _stub_start_boundaries(tmp_path, monkeypatch)
+    (tmp_path / "config.yaml").write_text(
+        "version: '1'\n"
+        "provider:\n"
+        "  provider_type: llamacpp\n"
+        "  base_url: http://localhost:8080/v1\n"
+        "  default_model: test-model\n"
+        "  api_key: none\n"
+        "server:\n"
+        "  runtime: llamacpp\n"
+        "  launch: binary\n"
+        "  binary: /x/llama-server\n"
+        "  model: test-model\n"
+    )
+    monkeypatch.setattr(
+        model_ops, "list_live_models", _fake_live_models(["test-model"]), raising=False,
+    )
+    errs = _capture_err_console(monkeypatch)
+
+    with pytest.raises(typer.Exit) as ei:
+        await _start_async(None, False, False, str(tmp_path), model_override="other-model")
+    assert ei.value.exit_code != 0
+
+    out = "\n".join(errs)
+    assert "other-model" in out and "not currently" in out
+    assert "harness-managed single-model server" in out
+    assert "localharness model" in out and "/model" in out
+
+
+async def test_model_override_falls_back_to_configured_when_unreachable(tmp_path, monkeypatch):
+    """When the live probe can't reach the endpoint, --model falls back to the CONFIGURED
+    (available_models) list rather than failing outright — it only hard-errors when the
+    requested model is in neither list."""
+    from localharness.cli import model_ops
+    from localharness.cli.start_cmd import _start_async
+
+    _stub_start_boundaries(tmp_path, monkeypatch)
+    (tmp_path / "config.yaml").write_text(
+        "version: '1'\n"
+        "provider:\n"
+        "  provider_type: ollama\n"
+        "  base_url: http://localhost:11434/v1\n"
+        "  default_model: test-model\n"
+        "  api_key: none\n"
+        "  available_models: [test-model, configured-only-model]\n"
+    )
+    monkeypatch.setattr(
+        model_ops, "list_live_models", _fake_live_models([], reachable=False), raising=False,
+    )
+
+    await _start_async(
+        None, False, False, str(tmp_path), model_override="configured-only-model"
+    )  # must NOT raise — the requested model is in the configured fallback list
+
+    rows = _read_sessions(tmp_path)
+    assert len(rows) == 1 and rows[0][3] == "complete"
+
+
+async def test_model_override_unreachable_and_unconfigured_still_errors(tmp_path, monkeypatch):
+    """The fallback above is not a blanket pass — unreachable AND not even configured must
+    still hard-error (never silently start against a model nobody named)."""
+    import typer
+    from localharness.cli import model_ops
+    from localharness.cli.start_cmd import _start_async
+
+    _stub_start_boundaries(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        model_ops, "list_live_models", _fake_live_models([], reachable=False), raising=False,
+    )
+
+    with pytest.raises(typer.Exit):
+        await _start_async(None, False, False, str(tmp_path), model_override="ghost-model")
+
+
+def _write_provider_only_config(tmp_path, *, available_models=None):
+    lines = [
+        "version: '1'",
+        "provider:",
+        "  provider_type: ollama",
+        "  base_url: http://localhost:11434/v1",
+        "  default_model: test-model",
+        "  api_key: none",
+    ]
+    if available_models is not None:
+        lines.append("  available_models: [" + ", ".join(available_models) + "]")
+    (tmp_path / "config.yaml").write_text("\n".join(lines) + "\n")
+
+
+async def test_list_models_reachable_shows_active_marker(tmp_path, monkeypatch):
+    """Reachable state: live models print with '(serving)', and the configured default is
+    marked [active]."""
+    import typer
+    from localharness.cli import model_ops
+    from localharness.cli.start_cmd import _start_async
+
+    _write_provider_only_config(tmp_path)
+    monkeypatch.setattr(
+        model_ops, "list_live_models",
+        _fake_live_models(["test-model", "alt-model"]), raising=False,
+    )
+    printed = _capture_start_console(monkeypatch)
+
+    with pytest.raises(typer.Exit) as ei:
+        await _start_async(None, False, False, str(tmp_path), list_models=True)
+    assert ei.value.exit_code == 0
+
+    out = "\n".join(printed)
+    assert "test-model" in out and "[active]" in out
+    assert "alt-model" in out and "(serving)" in out
+
+
+async def test_list_models_unreachable_errors(tmp_path, monkeypatch):
+    """Unreachable state with nothing configured either: a clear error, exit 2 — never a bare
+    empty list that looks like a legitimate zero-model server."""
+    import typer
+    from localharness.cli import model_ops
+    from localharness.cli.start_cmd import _start_async
+
+    _write_provider_only_config(tmp_path)
+    monkeypatch.setattr(
+        model_ops, "list_live_models", _fake_live_models([], reachable=False), raising=False,
+    )
+    errs = _capture_err_console(monkeypatch)
+
+    with pytest.raises(typer.Exit) as ei:
+        await _start_async(None, False, False, str(tmp_path), list_models=True)
+    assert ei.value.exit_code == 2
+
+    out = "\n".join(errs)
+    assert "could not reach" in out.lower()
+
+
+async def test_list_models_nothing_live_shows_none(tmp_path, monkeypatch):
+    """Reachable but zero models being served AND none configured: a plain '(none)', not an
+    error — the server answered, it just isn't serving anything right now."""
+    import typer
+    from localharness.cli import model_ops
+    from localharness.cli.start_cmd import _start_async
+
+    _write_provider_only_config(tmp_path)
+    monkeypatch.setattr(
+        model_ops, "list_live_models", _fake_live_models([], reachable=True), raising=False,
+    )
+    printed = _capture_start_console(monkeypatch)
+
+    with pytest.raises(typer.Exit) as ei:
+        await _start_async(None, False, False, str(tmp_path), list_models=True)
+    assert ei.value.exit_code == 0
+
+    out = "\n".join(printed)
+    assert "(none)" in out


### PR DESCRIPTION
## Summary
Adds a session-only model override and a standalone Hugging Face download path, for the workflow of trying a different already-served model without touching config, or fetching one GGUF quant out of a multi-quant repo ahead of time.

### `localharness start --model <name>` / `-m`
Session-only override — never persisted to config.yaml, unlike `localharness model <name>`. Restricted to a model already being served:
- Attach-only providers (Ollama, LM Studio) can pick any live model freely.
- A harness-managed single-model server (llama.cpp/vLLM) errors out if asked to switch to a model it isn't currently serving, pointing at `localharness model <name>` (persist + restart) or the REPL `/model` command (live restart) instead — deliberately not auto-restarting from this flag.

### `localharness start --list-models`
Lists live-served + configured models and exits, without loading agents or starting a session.

### `localharness model --download <repo_id> [--file <name>]`
Standalone HF download, independent of `init`'s guided vLLM setup. Without `--file`, pulls the whole repo snapshot (right for vLLM/transformers checkpoints). With `--file`, fetches exactly one sibling file via `hf_hub_download` — the correct way to grab a single GGUF quant (e.g. `Qwen3-32B-Q4_K_M.gguf`) out of a repo that ships several, instead of downloading every quant variant.

## Docs
- README: CLI table + quick start blurb.
- `docs/runtimes/llamacpp.md`: new "Downloading a GGUF from Hugging Face" section.
- `CHANGELOG.md`: Unreleased entry.

## Testing
- `uv run pytest tests/unit/test_model_cmd.py tests/unit/test_repl_model_cmd.py tests/unit/test_start_cmd.py` — 154 passed
- `uv run pytest tests/unit` (full suite) — 2582 passed, 4 skipped, 4 xfailed (pre-existing, unrelated)
- `ruff check` / `mypy` on changed files — no new issues (existing findings pre-date this change, confirmed via `git stash` diff)
- Manual: `localharness start --help` / `localharness model --help` render the new flags correctly

Co-Authored-By: Warp <agent@warp.dev>
