### PR TITLE
feat(doctor): warn when an AMD GPU is present but llama.cpp is Vulkan-linked, not HIP

### DIFF
--- a/src/localharness/cli/doctor_cmd.py
+++ b/src/localharness/cli/doctor_cmd.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Annotated
@@ -19,6 +20,59 @@ console = Console()
 _PASS = "[green]✓[/green]"
 _FAIL = "[bold red]✗[/bold red]"
 _INFO = "[cyan]i[/cyan]"
+_WARN = "[yellow]⚠[/yellow]"
+
+_AMD_PCI_VENDOR_ID = "0x1002"
+
+
+def _has_amd_gpu() -> bool:
+    """An AMD/ATI GPU is present, via sysfs PCI vendor IDs — no subprocess, no extra binary
+    required (rocm-smi/lspci may not be installed even when an AMD GPU is). Linux-only
+    (issue #144's plan): returns False, never raises, on any other platform, and degrades the
+    same way in a container/sandbox where /sys/class/drm isn't readable."""
+    if not sys.platform.startswith("linux"):
+        return False
+    try:
+        for vendor_file in Path("/sys/class/drm").glob("card[0-9]*/device/vendor"):
+            try:
+                if vendor_file.read_text().strip().lower() == _AMD_PCI_VENDOR_ID:
+                    return True
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return False
+
+
+def _llama_server_linked_backends(binary: str) -> "set[str] | None":
+    """Which GPU backend(s) `binary` is linked against — a subset of {'hip', 'vulkan'} (both
+    empty means CPU-only/unknown backend libs). None means UNDETERMINABLE (not Linux, `ldd`
+    missing, binary missing/unreadable) — callers must treat that as "can't tell", never as
+    "CPU-only", or a missing `ldd` would falsely read as a healthy CPU build.
+
+    Recognizes both the current llama.cpp/ggml library names (`libggml-hip`/`libggml-vulkan`)
+    and the underlying vendor libs they link against (`libamdhip64`/`libvulkan`) so this works
+    across the `LLAMA_HIPBLAS`/`GGML_HIPBLAS` -> `GGML_HIP` build-flag rename too (issue #144).
+    """
+    if not sys.platform.startswith("linux"):
+        return None
+    if not Path(binary).is_file():
+        return None
+    try:
+        proc = subprocess.run(
+            ["ldd", binary], capture_output=True, text=True, timeout=5.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    text = proc.stdout.lower()
+    backends: set[str] = set()
+    if "libamdhip64" in text or "libggml-hip" in text:
+        backends.add("hip")
+    if "libvulkan" in text or "libggml-vulkan" in text:
+        backends.add("vulkan")
+    return backends
 
 
 def _strip_v1(base_url: str) -> str:
@@ -338,6 +392,31 @@ def doctor(
                         )
                 except Exception:
                     pass  # /props absent on older builds — the check is advisory only
+
+                # AMD backend check (#144): llama.cpp's cmake quietly PREFERS Vulkan over
+                # HIP/ROCm unless the build explicitly disables it, and -ngl offloads onto the
+                # GPU either way — so a Vulkan build looks perfectly healthy while running the
+                # slower, less-tested backend. Only checkable for a harness-MANAGED llama.cpp
+                # server: we need the actual binary path, which an attach-only endpoint never
+                # gives us. Advisory only (never fails) — a Vulkan build still works.
+                if (
+                    harness.server is not None
+                    and harness.server.runtime == "llamacpp"
+                    and harness.server.binary
+                ):
+                    backends = _llama_server_linked_backends(harness.server.binary)
+                    if (
+                        backends is not None
+                        and "vulkan" in backends
+                        and "hip" not in backends
+                        and _has_amd_gpu()
+                    ):
+                        console.print(
+                            f"{_WARN} AMD GPU detected, but {harness.server.binary} is linked "
+                            f"against Vulkan, not HIP/ROCm — it will run, but on the slower, "
+                            f"less-tested backend. Rebuild with -DGGML_HIP=ON -DGGML_VULKAN=OFF "
+                            f"-DAMDGPU_TARGETS=<your gfx> (see docs/runtimes/llamacpp.md)."
+                        )
             else:  # vllm (and unknown): the exact /tokenize {count} contract is expected here
                 try:
                     tk = httpx.post(

--- a/tests/unit/test_doctor_cmd.py
+++ b/tests/unit/test_doctor_cmd.py
@@ -376,6 +376,189 @@ def test_doctor_llamacpp_single_slot_stays_silent(mock_httpx, tmp_path):
     assert "--parallel 1" not in result.output
 
 
+# --- #144: AMD GPU present + llama.cpp binary linked against Vulkan, not HIP -> warn --------
+
+
+def _write_managed_llamacpp_config(tmp_path: Path, binary: str, model: str = "m") -> None:
+    (tmp_path / "config.yaml").write_text(
+        'version: "1"\n'
+        "provider:\n"
+        "  provider_type: llamacpp\n"
+        "  base_url: http://localhost:8080/v1\n"
+        f"  default_model: {model}\n"
+        "  available_models:\n"
+        f"    - {model}\n"
+        "  supports_function_calling: true\n"
+        "  timeout_seconds: 600.0\n"
+        "server:\n"
+        "  runtime: llamacpp\n"
+        f"  binary: {binary}\n"
+        f"  model: {model}.gguf\n"
+        "  port: 8080\n"
+    )
+
+
+def _basic_llamacpp_mocks(mock_httpx, model: str = "m") -> None:
+    mock_httpx.get.return_value = _models_resp({"data": [{"id": model}]})
+    tok = MagicMock()
+    tok.status_code = 200
+    tok.json.return_value = {"tokens": [1, 2]}
+    mock_httpx.post.return_value = tok
+
+
+@patch("localharness.cli.doctor_cmd._has_amd_gpu", return_value=True)
+@patch("localharness.cli.doctor_cmd._llama_server_linked_backends", return_value={"vulkan"})
+@patch("localharness.cli.doctor_cmd.httpx")
+def test_doctor_warns_amd_gpu_vulkan_only_binary(mock_httpx, mock_backends, mock_amd, tmp_path):
+    """AMD GPU present + a managed llama.cpp binary linked ONLY against Vulkan -> a WARN
+    advisory naming the fix, but doctor still exits 0 (a Vulkan build still works)."""
+    binary = str(tmp_path / "llama-server")
+    _write_managed_llamacpp_config(tmp_path, binary)
+    _basic_llamacpp_mocks(mock_httpx)
+
+    result = runner.invoke(app, ["doctor", "--config-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "Vulkan, not HIP/ROCm" in result.output
+    assert "-DGGML_HIP=ON" in result.output
+    mock_backends.assert_called_once_with(binary)
+
+
+@patch("localharness.cli.doctor_cmd._has_amd_gpu", return_value=True)
+@patch("localharness.cli.doctor_cmd._llama_server_linked_backends", return_value={"hip", "vulkan"})
+@patch("localharness.cli.doctor_cmd.httpx")
+def test_doctor_silent_when_binary_is_hip_linked(mock_httpx, mock_backends, mock_amd, tmp_path):
+    """A binary linked against HIP (even alongside Vulkan support compiled in) is fine —
+    the warning is specifically for Vulkan-without-HIP."""
+    binary = str(tmp_path / "llama-server")
+    _write_managed_llamacpp_config(tmp_path, binary)
+    _basic_llamacpp_mocks(mock_httpx)
+
+    result = runner.invoke(app, ["doctor", "--config-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "HIP/ROCm" not in result.output
+
+
+@patch("localharness.cli.doctor_cmd._has_amd_gpu", return_value=False)
+@patch("localharness.cli.doctor_cmd._llama_server_linked_backends", return_value={"vulkan"})
+@patch("localharness.cli.doctor_cmd.httpx")
+def test_doctor_silent_without_amd_gpu(mock_httpx, mock_backends, mock_amd, tmp_path):
+    """A Vulkan-only build is fine on non-AMD hardware (e.g. Intel/NVIDIA Vulkan) — the
+    warning is AMD-specific (that's where the HIP/ROCm backend applies)."""
+    binary = str(tmp_path / "llama-server")
+    _write_managed_llamacpp_config(tmp_path, binary)
+    _basic_llamacpp_mocks(mock_httpx)
+
+    result = runner.invoke(app, ["doctor", "--config-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "HIP/ROCm" not in result.output
+
+
+@patch("localharness.cli.doctor_cmd._has_amd_gpu", return_value=True)
+@patch("localharness.cli.doctor_cmd._llama_server_linked_backends", return_value=None)
+@patch("localharness.cli.doctor_cmd.httpx")
+def test_doctor_silent_when_backend_undeterminable(mock_httpx, mock_backends, mock_amd, tmp_path):
+    """None (ldd missing/failed, non-Linux) means "can't tell" — must never be treated as
+    evidence of a problem."""
+    binary = str(tmp_path / "llama-server")
+    _write_managed_llamacpp_config(tmp_path, binary)
+    _basic_llamacpp_mocks(mock_httpx)
+
+    result = runner.invoke(app, ["doctor", "--config-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "HIP/ROCm" not in result.output
+
+
+@patch("localharness.cli.doctor_cmd._has_amd_gpu", return_value=True)
+@patch("localharness.cli.doctor_cmd._llama_server_linked_backends")
+@patch("localharness.cli.doctor_cmd.httpx")
+def test_doctor_skips_amd_check_for_attach_only_llamacpp(mock_httpx, mock_backends, mock_amd, tmp_path):
+    """No `server:` block (attach-only endpoint) -> the harness has no binary path to inspect,
+    so the check must skip entirely rather than guess."""
+    _write_config(tmp_path, "llamacpp", "http://localhost:8080/v1", model="m")
+    _basic_llamacpp_mocks(mock_httpx)
+
+    result = runner.invoke(app, ["doctor", "--config-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "HIP/ROCm" not in result.output
+    mock_backends.assert_not_called()
+
+
+def test_has_amd_gpu_reads_sysfs_pci_vendor(tmp_path, monkeypatch):
+    """_has_amd_gpu reads /sys/class/drm/card*/device/vendor for AMD's PCI vendor id
+    (0x1002) — no subprocess, so it works even without rocm-smi/lspci installed."""
+    from localharness.cli import doctor_cmd
+
+    drm = tmp_path / "drm"
+    (drm / "card0" / "device").mkdir(parents=True)
+    (drm / "card0" / "device" / "vendor").write_text("0x1002\n")
+    monkeypatch.setattr(doctor_cmd, "Path", lambda p: Path(str(drm)) if p == "/sys/class/drm" else Path(p))
+    monkeypatch.setattr(doctor_cmd.sys, "platform", "linux")
+    assert doctor_cmd._has_amd_gpu() is True
+
+
+def test_has_amd_gpu_false_for_other_vendor(tmp_path, monkeypatch):
+    from localharness.cli import doctor_cmd
+
+    drm = tmp_path / "drm"
+    (drm / "card0" / "device").mkdir(parents=True)
+    (drm / "card0" / "device" / "vendor").write_text("0x10de\n")  # NVIDIA
+    monkeypatch.setattr(doctor_cmd, "Path", lambda p: Path(str(drm)) if p == "/sys/class/drm" else Path(p))
+    monkeypatch.setattr(doctor_cmd.sys, "platform", "linux")
+    assert doctor_cmd._has_amd_gpu() is False
+
+
+def test_has_amd_gpu_false_off_linux(monkeypatch):
+    from localharness.cli import doctor_cmd
+
+    monkeypatch.setattr(doctor_cmd.sys, "platform", "win32")
+    assert doctor_cmd._has_amd_gpu() is False
+
+
+def test_linked_backends_none_off_linux(monkeypatch):
+    from localharness.cli import doctor_cmd
+
+    monkeypatch.setattr(doctor_cmd.sys, "platform", "darwin")
+    assert doctor_cmd._llama_server_linked_backends("/usr/bin/anything") is None
+
+
+def test_linked_backends_none_when_binary_missing(monkeypatch):
+    from localharness.cli import doctor_cmd
+
+    monkeypatch.setattr(doctor_cmd.sys, "platform", "linux")
+    assert doctor_cmd._llama_server_linked_backends("/no/such/binary") is None
+
+
+def test_linked_backends_detects_hip_and_vulkan(tmp_path, monkeypatch):
+    """Recognizes both the current library names and the old-tree spellings the #144 docs
+    fix also had to account for (LLAMA_HIPBLAS/GGML_HIPBLAS -> GGML_HIP rename)."""
+    from localharness.cli import doctor_cmd
+
+    binary = tmp_path / "llama-server"
+    binary.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(doctor_cmd.sys, "platform", "linux")
+
+    def fake_run(cmd, capture_output, text, timeout):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "libamdhip64.so.7 => /opt/rocm/lib/libamdhip64.so.7\n"
+        return result
+    monkeypatch.setattr(doctor_cmd.subprocess, "run", fake_run)
+    assert doctor_cmd._llama_server_linked_backends(str(binary)) == {"hip"}
+
+
+def test_linked_backends_none_when_ldd_fails(tmp_path, monkeypatch):
+    from localharness.cli import doctor_cmd
+
+    binary = tmp_path / "llama-server"
+    binary.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(doctor_cmd.sys, "platform", "linux")
+
+    def fake_run(cmd, capture_output, text, timeout):
+        raise FileNotFoundError("ldd not found")
+    monkeypatch.setattr(doctor_cmd.subprocess, "run", fake_run)
+    assert doctor_cmd._llama_server_linked_backends(str(binary)) is None
+
+
 @patch("localharness.cli.doctor_cmd.httpx")
 def test_doctor_vllm_message_level_exact(mock_httpx, tmp_path):
     """vLLM whose /tokenize answers messages-mode: doctor reports message-level exactness —


### PR DESCRIPTION
## Summary
Second half of #144's plan (the docs half already landed in main as commit `33a796b`).

llama.cpp's cmake quietly **prefers Vulkan over HIP/ROCm** unless a build explicitly disables it, and `-ngl` offloads onto the GPU the same way on either backend — so a Vulkan build looks perfectly healthy while running the slower, less-tested backend, with nothing telling the user until they go looking (as happened here, on real AMD hardware).

### What's added
Two standalone, unit-testable helpers in `doctor_cmd.py`:
- `_has_amd_gpu()` — sysfs PCI vendor-id sniff (`0x1002`) under `/sys/class/drm`. No subprocess, no dependency on `rocm-smi`/`lspci` being installed. Linux-only; degrades to `False` (never raises) elsewhere.
- `_llama_server_linked_backends(binary)` — `ldd`s the binary and looks for HIP vs Vulkan backend libs. Recognizes both the current library names (`libggml-hip`/`libggml-vulkan`) and the vendor libs underneath (`libamdhip64`/`libvulkan`), so it works across the `LLAMA_HIPBLAS`/`GGML_HIPBLAS` → `GGML_HIP` build-flag rename too. Returns `None` (never an empty set) when undeterminable — `ldd` missing, binary missing, non-Linux — so "can't tell" is never misread as "CPU-only".

The check itself only runs for a harness-**managed** llama.cpp server (`server.runtime == "llamacpp"` with a `binary` path) — an attach-only llama.cpp endpoint gives the harness no binary to inspect, so it skips rather than guessing. It's advisory only (never added to `failures`, exit code unaffected): a Vulkan build still works, just slower.

## Testing
- Live-verified against real AMD hardware (Radeon AI PRO R9700, gfx1201): silent against the current HIP-linked `llama-server` build (`_has_amd_gpu()` → `True`, `_llama_server_linked_backends(...)` → `{'hip'}`), and `localharness doctor` runs clean against it.
- New unit tests cover: the warning firing (AMD + Vulkan-only), staying silent when HIP is linked, staying silent without an AMD GPU, staying silent when the backend is undeterminable (`None`), skipping entirely for an attach-only endpoint (no binary to inspect), and the two helpers directly (sysfs parsing, `ldd` output parsing, missing binary, missing `ldd`).
- `uv run pytest tests/unit tests/integration` — 2667 passed, 17 skipped, 4 xfailed (no regressions)
- `ruff`/`mypy` on changed files — no new findings (confirmed via `git stash` diff against the pre-change tree)

Co-Authored-By: Warp <agent@warp.dev>
